### PR TITLE
`ptype` agnostic POST endpoints

### DIFF
--- a/vetiver/handlers/pytorch_vt.py
+++ b/vetiver/handlers/pytorch_vt.py
@@ -52,7 +52,7 @@ class TorchHandler:
         """
         ...
 
-    def handler_predict(self, input_data):
+    def handler_predict(self, input_data, check_ptype):
         """Generates method for /predict endpoint in VetiverAPI
 
         The `handler_predict` function executes at each API call. Use this
@@ -69,7 +69,7 @@ class TorchHandler:
         prediction
             Prediction from model
         """
-        if self.save_ptype == True:
+        if check_ptype == True:
             input_data = np.array(input_data, dtype=np.array(self.ptype_data).dtype)
             prediction = self.model(torch.from_numpy(input_data))
         else:

--- a/vetiver/handlers/pytorch_vt.py
+++ b/vetiver/handlers/pytorch_vt.py
@@ -46,11 +46,18 @@ class TorchHandler:
 
     def handler_startup():
         """Include required packages for prediction
+
+        The `handler_startup` function executes when the API starts. Use this
+        function for tasks like loading packages.
         """
         ...
 
-    def handler_predict(self, input_data, argmax=False):
+    def handler_predict(self, input_data):
         """Generates method for /predict endpoint in VetiverAPI
+
+        The `handler_predict` function executes at each API call. Use this
+        function for calling `predict()` and any other tasks that must be executed
+        at each API call.
 
         Parameters
         ----------
@@ -62,12 +69,13 @@ class TorchHandler:
         prediction
             Prediction from model
         """
-        dt = np.array(self.ptype_data).dtype
-        input_data = np.array(input_data, dtype=dt)
-        prediction = self.model(torch.from_numpy(input_data))
-
-        if argmax:
-
-            prediction = np.argmax(prediction)
+        if self.save_ptype == True:
+            input_data = np.array(input_data, dtype=np.array(self.ptype_data).dtype)
+            prediction = self.model(torch.from_numpy(input_data))
+        else:
+            input_data = input_data.split(",")  # user delimiter ?
+            input_data = np.array(input_data, dtype=np.array(self.ptype_data).dtype)
+            reshape_data = input_data.reshape(1, -1)
+            prediction = self.model(torch.from_numpy(reshape_data))
 
         return prediction

--- a/vetiver/handlers/sklearn_vt.py
+++ b/vetiver/handlers/sklearn_vt.py
@@ -1,5 +1,6 @@
 from ..ptype import _vetiver_create_ptype
 import sklearn
+import numpy as np
 
 class SKLearnHandler:
     """Handler class for creating VetiverModels with sklearn.
@@ -43,7 +44,20 @@ class SKLearnHandler:
         return ptype
 
     def handler_startup():
+        """Include required packages for prediction
+
+        The `handler_startup` function executes when the API starts. Use this
+        function for tasks like loading packages.
+        """
+        ...
+
+
+    def handler_predict(self, input_data):
         """Generates method for /predict endpoint in VetiverAPI
+
+        The `handler_predict` function executes at each API call. Use this
+        function for calling `predict()` and any other tasks that must be executed
+        at each API call.
 
         Parameters
         ----------
@@ -55,13 +69,12 @@ class SKLearnHandler:
         prediction
             Prediction from model
         """
-        ...
-
-    def handler_predict(self, input_data, predict_proba: bool = False):
-
-        if predict_proba:
-            prediction = self.model.predict_proba([input_data])
-
-        prediction = self.model.predict([input_data])
+        if self.save_ptype == True:
+            prediction = self.model.predict([input_data])
+        else:
+            input_data = input_data.split(",")  # user delimiter ?
+            input_data = np.asarray(input_data)
+            reshape_data = input_data.reshape(1, -1)
+            prediction = self.model.predict(reshape_data)
 
         return prediction

--- a/vetiver/handlers/sklearn_vt.py
+++ b/vetiver/handlers/sklearn_vt.py
@@ -52,7 +52,7 @@ class SKLearnHandler:
         ...
 
 
-    def handler_predict(self, input_data):
+    def handler_predict(self, input_data, check_ptype):
         """Generates method for /predict endpoint in VetiverAPI
 
         The `handler_predict` function executes at each API call. Use this
@@ -69,7 +69,7 @@ class SKLearnHandler:
         prediction
             Prediction from model
         """
-        if self.save_ptype == True:
+        if check_ptype == True:
             prediction = self.model.predict([input_data])
         else:
             input_data = input_data.split(",")  # user delimiter ?

--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -2,9 +2,7 @@ from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, RedirectResponse
 import uvicorn
 from typing import Callable, List, Optional
-from logging import warn
 import requests
-import numpy as np
 import pandas as pd
 
 from .vetiver_model import VetiverModel
@@ -96,10 +94,7 @@ class VetiverAPI:
             @app.post("/predict/")
             async def prediction(input_data):
 
-                input_data = input_data.split(" ")  # user delimiter ?
-                input_data = np.asarray(input_data)
-                reshape_data = input_data.reshape(1, -1)
-                y = self.model.handler_predict(reshape_data)
+                y = self.model.handler_predict(input_data)
 
                 return {"prediction": y.tolist()}
 

--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -1,8 +1,7 @@
-from tabnanny import check
 from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse
 import uvicorn
-from typing import Callable, List, Optional
+from typing import Callable, Optional
 import requests
 import pandas as pd
 

--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -121,18 +121,16 @@ class VetiverAPI:
 
             @self.app.post("/" + endpoint_name + "/")
             async def custom_endpoint(input_data: self.model.ptype):
-                served_data = _prepare_data(input_data)
-                new = endpoint_fx(pd.Series(served_data))
-
+                y = _prepare_data(input_data)
+                new = endpoint_fx(pd.Series(y))
                 return {endpoint_name: new.tolist()}
 
         else:
 
             @self.app.post("/" + endpoint_name + "/")
             async def custom_endpoint(input_data: Request):
-                served_data = await input_data.get()
-                served_data = _prepare_data(served_data.body())
-                new = endpoint_fx(served_data)
+                y = await input_data.json()
+                new = endpoint_fx(pd.Series(y))
 
                 return {endpoint_name: new.tolist()}
 

--- a/vetiver/tests/test_add_endpoint.py
+++ b/vetiver/tests/test_add_endpoint.py
@@ -4,7 +4,7 @@ from vetiver import mock, VetiverModel, VetiverAPI
 from fastapi.testclient import TestClient
 
 
-def _start_application():
+def _start_application(check_ptype):
     X, y = mock.get_mock_data()
     model = mock.get_mock_model().fit(X, y)
     v = VetiverModel(
@@ -19,18 +19,28 @@ def _start_application():
     def sum_values(x):
         return x.sum()
 
-    app = VetiverAPI(v)
+    app = VetiverAPI(v, check_ptype=check_ptype)
 
     app.vetiver_post(sum_values, "sum")
 
     return app
 
 
-def test_endpoint_adds():
-    app = _start_application().app
+def test_endpoint_adds_ptype():
+    app = _start_application(check_ptype=True).app
 
     client = TestClient(app)
     data = {"B": 0, "C": 0, "D": 0}
+    response = client.post("/sum/", json=data)
+    assert response.status_code == 200, response.text
+    assert response.json() == {"sum": 0}, response.json()
+
+
+def test_endpoint_adds_no_ptype():
+    app = _start_application(check_ptype=False).app
+
+    client = TestClient(app)
+    data = [0,0,0]
     response = client.post("/sum/", json=data)
     assert response.status_code == 200, response.text
     assert response.json() == {"sum": 0}, response.json()

--- a/vetiver/tests/test_ping_server.py
+++ b/vetiver/tests/test_ping_server.py
@@ -33,12 +33,3 @@ def test_get_docs():
     client = TestClient(_start_application().app)
     response = client.get("/docs")
     assert response.status_code == 200, response.text
-
-
-def test_predict_endpoint():
-    np.random.seed(500)
-    client = TestClient(_start_application().app)
-    data = {"B": 0, "C": 0, "D": 0}
-    response = client.post("/predict/", json=data)
-    assert response.status_code == 200, response.text
-    assert response.json() == {"prediction": [44.47]}, response.json()

--- a/vetiver/tests/test_pytorch.py
+++ b/vetiver/tests/test_pytorch.py
@@ -70,6 +70,18 @@ def test_torch_predict_ptype():
 
     assert response.status_code == 200, response.text
 
+def test_torch_predict_ptype_error():
+
+    x_train, torch_model = _build_torch_v()
+    v = VetiverModel(torch_model, save_ptype=True, ptype_data=x_train)
+    v_api = VetiverAPI(v)
+
+    client = TestClient(v_api.app)
+    data = {"0": "bad"}
+    response = client.post("/predict/", json=data)
+
+    assert response.status_code == 422, response.text # value is not a valid float
+
 
 def test_torch_predict_no_ptype():
 
@@ -78,7 +90,18 @@ def test_torch_predict_no_ptype():
     v_api = VetiverAPI(v, check_ptype=False)
 
     client = TestClient(v_api.app)
-    data = 3.3
-    response = client.post(f"/predict/?input_data={data}")
-
+    data = '3.3'
+    response = client.post("/predict/", json=data)
     assert response.status_code == 200, response.text
+
+
+def test_torch_predict_no_ptype_error():
+
+    x_train, torch_model = _build_torch_v()
+    v = VetiverModel(torch_model, save_ptype=False, ptype_data=x_train)
+    v_api = VetiverAPI(v, check_ptype=False)
+
+    client = TestClient(v_api.app)
+    data = 'bad'
+    with pytest.raises(ValueError):
+        client.post("/predict/", json=data)

--- a/vetiver/tests/test_pytorch.py
+++ b/vetiver/tests/test_pytorch.py
@@ -58,7 +58,7 @@ def test_vetiver_build():
     assert vt2.model == torch_model
 
 
-def test_torch_predict():
+def test_torch_predict_ptype():
 
     x_train, torch_model = _build_torch_v()
     v = VetiverModel(torch_model, save_ptype=True, ptype_data=x_train)
@@ -67,5 +67,18 @@ def test_torch_predict():
     client = TestClient(v_api.app)
     data = {"0": 3.3}
     response = client.post("/predict/", json=data)
+
+    assert response.status_code == 200, response.text
+
+
+def test_torch_predict_no_ptype():
+
+    x_train, torch_model = _build_torch_v()
+    v = VetiverModel(torch_model, save_ptype=False, ptype_data=x_train)
+    v_api = VetiverAPI(v, check_ptype=False)
+
+    client = TestClient(v_api.app)
+    data = 3.3
+    response = client.post(f"/predict/?input_data={data}")
 
     assert response.status_code == 200, response.text

--- a/vetiver/tests/test_sklearn.py
+++ b/vetiver/tests/test_sklearn.py
@@ -32,10 +32,26 @@ def test_predict_endpoint_ptype():
     assert response.json() == {"prediction": [44.47]}, response.json()
 
 
+def test_predict_endpoint_ptype_error():
+    np.random.seed(500)
+    client = TestClient(_start_application(save_ptype=True).app)
+    data = {"B": 0, "C": 'a', "D": 0}
+    response = client.post("/predict/", json=data)
+    assert response.status_code == 422, response.text # value is not a valid integer
+
+
 def test_predict_endpoint_no_ptype():
     np.random.seed(500)
     client = TestClient(_start_application(save_ptype=False).app)
-    data = [0,0,0]
-    response = client.post(f"/predict/?input_data={'%20'.join(map(str,data))}")
+    data = '0,0,0'
+    response = client.post("/predict/", json=data)
     assert response.status_code == 200, response.text
     assert response.json() == {"prediction": [44.47]}, response.json()
+
+
+def test_predict_endpoint_no_ptype_error():
+    np.random.seed(500)
+    client = TestClient(_start_application(save_ptype=False).app)
+    data = ['hell0',9,32.0]
+    with pytest.raises(AttributeError):
+        client.post("/predict/", json=data)

--- a/vetiver/tests/test_sklearn.py
+++ b/vetiver/tests/test_sklearn.py
@@ -1,0 +1,41 @@
+from os import sep
+import pytest
+
+from vetiver import mock, VetiverModel, VetiverAPI
+from fastapi.testclient import TestClient
+import numpy as np
+
+
+def _start_application(save_ptype: bool):
+    X, y = mock.get_mock_data()
+    model = mock.get_mock_model().fit(X, y)
+    v = VetiverModel(
+        model=model,
+        save_ptype=save_ptype,
+        ptype_data=X,
+        model_name="my_model",
+        versioned=None,
+        description="A regression model for testing purposes",
+    )
+
+    app = VetiverAPI(v, check_ptype=save_ptype)
+
+    return app
+
+
+def test_predict_endpoint_ptype():
+    np.random.seed(500)
+    client = TestClient(_start_application(save_ptype=True).app)
+    data = {"B": 0, "C": 0, "D": 0}
+    response = client.post("/predict/", json=data)
+    assert response.status_code == 200, response.text
+    assert response.json() == {"prediction": [44.47]}, response.json()
+
+
+def test_predict_endpoint_no_ptype():
+    np.random.seed(500)
+    client = TestClient(_start_application(save_ptype=False).app)
+    data = [0,0,0]
+    response = client.post(f"/predict/?input_data={'%20'.join(map(str,data))}")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"prediction": [44.47]}, response.json()


### PR DESCRIPTION
closes #10 

Implementing Requests for `check_ptype=False` to ensure all data comes into body of request
Moving most handling data to `handler_predict` rather than in `server.py` for legibility
Adding and rearranging tests for more robust checking