### PR TITLE
return dataframes in `predict()`

### DIFF
--- a/vetiver/tests/test_predict.py
+++ b/vetiver/tests/test_predict.py
@@ -28,6 +28,7 @@ def test_predict_sklearn_dict_ptype():
 
     assert isinstance(response, pd.DataFrame), response
     assert response.iloc[0,0] == 44.47
+    assert len(response) == 1
 
 
 def test_predict_sklearn_no_ptype():
@@ -74,9 +75,10 @@ def test_predict_sklearn_df_check_ptype():
     assert len(response) == 100
 
 
-def test_predict_sklearn_df_no_ptype():
+def test_predict_sklearn_series_check_ptype():
     np.random.seed(500)
     X, y = mock.get_mock_data()
+    ser = pd.Series(data=[0,0,0])
     model = mock.get_mock_model().fit(X, y)
     v = VetiverModel(
         model=model,
@@ -86,13 +88,14 @@ def test_predict_sklearn_df_no_ptype():
         versioned=None,
         description="A regression model for testing purposes",
     )
-    app = VetiverAPI(v, check_ptype=False)
+    app = VetiverAPI(v, check_ptype=True)
     client = TestClient(app.app)
     
-    response = predict(endpoint=client, data=X)
+    response = predict(endpoint=client, data=ser)
 
     assert isinstance(response, pd.DataFrame), response
     assert response.iloc[0,0] == 44.47
+    assert len(response) == 1
 
 
 def test_predict_sklearn_type_error():
@@ -109,7 +112,7 @@ def test_predict_sklearn_type_error():
     )
     app = VetiverAPI(v, check_ptype=True)
     client = TestClient(app.app)
-    data = '0,0,0'
+    data = (0,0)
     
     with pytest.raises(TypeError):
         predict(endpoint=client, data=data)

--- a/vetiver/tests/test_predict.py
+++ b/vetiver/tests/test_predict.py
@@ -1,0 +1,115 @@
+import pytest
+
+import numpy as np
+import pandas as pd
+from fastapi.testclient import TestClient
+
+from vetiver import mock, VetiverModel, VetiverAPI
+from vetiver.server import predict
+
+
+def test_predict_sklearn_dict_ptype():
+    np.random.seed(500)
+    X, y = mock.get_mock_data()
+    model = mock.get_mock_model().fit(X, y)
+    v = VetiverModel(
+        model=model,
+        save_ptype=True,
+        ptype_data=X,
+        model_name="my_model",
+        versioned=None,
+        description="A regression model for testing purposes",
+    )
+    app = VetiverAPI(v, check_ptype=True)
+    client = TestClient(app.app)
+    data = {"B": 0, "C": 0, "D": 0}
+    
+    response = predict(endpoint=client, data=data)
+
+    assert isinstance(response, pd.DataFrame), response
+    assert response.iloc[0,0] == 44.47
+
+
+def test_predict_sklearn_no_ptype():
+    np.random.seed(500)
+    X, y = mock.get_mock_data()
+    model = mock.get_mock_model().fit(X, y)
+    v = VetiverModel(
+        model=model,
+        save_ptype=True,
+        ptype_data=X,
+        model_name="my_model",
+        versioned=None,
+        description="A regression model for testing purposes",
+    )
+    app = VetiverAPI(v, check_ptype=False)
+    client = TestClient(app.app)
+    
+    response = predict(endpoint=client, data=X)
+
+    assert isinstance(response, pd.DataFrame), response
+    assert response.iloc[0,0] == 44.47
+    assert len(response) == 100
+
+
+def test_predict_sklearn_df_check_ptype():
+    np.random.seed(500)
+    X, y = mock.get_mock_data()
+    model = mock.get_mock_model().fit(X, y)
+    v = VetiverModel(
+        model=model,
+        save_ptype=True,
+        ptype_data=X,
+        model_name="my_model",
+        versioned=None,
+        description="A regression model for testing purposes",
+    )
+    app = VetiverAPI(v, check_ptype=True)
+    client = TestClient(app.app)
+    
+    response = predict(endpoint=client, data=X)
+
+    assert isinstance(response, pd.DataFrame), response
+    assert response.iloc[0,0] == 44.47
+    assert len(response) == 100
+
+
+def test_predict_sklearn_df_no_ptype():
+    np.random.seed(500)
+    X, y = mock.get_mock_data()
+    model = mock.get_mock_model().fit(X, y)
+    v = VetiverModel(
+        model=model,
+        save_ptype=True,
+        ptype_data=X,
+        model_name="my_model",
+        versioned=None,
+        description="A regression model for testing purposes",
+    )
+    app = VetiverAPI(v, check_ptype=False)
+    client = TestClient(app.app)
+    
+    response = predict(endpoint=client, data=X)
+
+    assert isinstance(response, pd.DataFrame), response
+    assert response.iloc[0,0] == 44.47
+
+
+def test_predict_sklearn_type_error():
+    np.random.seed(500)
+    X, y = mock.get_mock_data()
+    model = mock.get_mock_model().fit(X, y)
+    v = VetiverModel(
+        model=model,
+        save_ptype=True,
+        ptype_data=X,
+        model_name="my_model",
+        versioned=None,
+        description="A regression model for testing purposes",
+    )
+    app = VetiverAPI(v, check_ptype=True)
+    client = TestClient(app.app)
+    data = '0,0,0'
+    
+    with pytest.raises(TypeError):
+        predict(endpoint=client, data=data)


### PR DESCRIPTION
returning dataframes when users send in data :D 

trying to think about how to test this? TestClient seems to only allow calls to be made from the client (ie, `client.post(data)`, not `predict(client_url, data)` where `predict` POSTs to the client URL.

ERROR is `requests.exceptions.ConnectionError: HTTPConnectionPool(host='testserver', port=80): Max retries exceeded with url: /predict (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x1481a0a30>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))`