### PR TITLE
Allow GHA testing on the dev branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   workflow_dispatch:
   push:
-    branches: ['main', 'dev-*']
+    branches: ['main', 'dev-*', 'dev']
   pull_request:
   release:
     types: [published]


### PR DESCRIPTION
This gives a contributor a fixed branch they can use for development
& testing on their fork without abusing the main branch which should
track upstream (tidymodels/main).

This is a QOL PR, it is tested [here](https://github.com/has2k1/vetiver-python/actions).